### PR TITLE
Http client timeouts

### DIFF
--- a/client.go
+++ b/client.go
@@ -40,6 +40,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type Client struct {
@@ -68,7 +69,9 @@ const (
 // To use API methods requiring auth then provide a http.Client which will perform the authentication for you e.g. oauth2
 func NewClient(httpClient *http.Client) *Client {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Timeout: time.Second * 10,
+		}
 	}
 	baseURL, _ := url.Parse(defaultBaseURL)
 

--- a/client.go
+++ b/client.go
@@ -37,6 +37,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -69,8 +70,15 @@ const (
 // To use API methods requiring auth then provide a http.Client which will perform the authentication for you e.g. oauth2
 func NewClient(httpClient *http.Client) *Client {
 	if httpClient == nil {
+		netTransport := &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: 5 * time.Second,
+			}).Dial,
+			TLSHandshakeTimeout: 5 * time.Second,
+		}
 		httpClient = &http.Client{
-			Timeout: time.Second * 10,
+			Timeout:   time.Second * 10,
+			Transport: netTransport,
 		}
 	}
 	baseURL, _ := url.Parse(defaultBaseURL)


### PR DESCRIPTION
The default http client doesn't specify any timeouts. The reason is the default client is created with Timeout is 0, which means no timeout. This means when the target server has outage or something like that, the connection from the client will be hang forever and will cause the user request (if one is associated) to be hang as well.

This PR adds code that caps the TCP connect and TLS handshake timeouts, as well as establishing an end-to-end request timeout.