### PR TITLE
chore: add rate limit error type

### DIFF
--- a/client.go
+++ b/client.go
@@ -155,6 +155,11 @@ func (c *Client) do(ctx context.Context, req *http.Request, v interface{}) (*Res
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == 429 {
+		return nil, &RateLimitError{}
+	}
+
 	err = json.NewDecoder(resp.Body).Decode(v)
 
 	r := newResponse(resp)

--- a/error.go
+++ b/error.go
@@ -1,0 +1,11 @@
+package client
+
+import "fmt"
+
+// RateLimitError contains information relating to this type of error
+type RateLimitError struct {
+}
+
+func (e *RateLimitError) Error() string {
+	return fmt.Sprintln("You have exceeeded the rate limit for this API.")
+}


### PR DESCRIPTION
This can be fleshed out in the future if we find a need for implementing rate limiting within the client. For now this allows the user to check the type of Error i.e. `if err == client.RateLimitError` and implement their own retry strategy e.g. Exponential Backoff.