### PR TITLE
feat(client): add http tracing

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -14,6 +15,16 @@ type Options struct {
 	*AuthConfigOptions
 	BaseURL   string
 	UserAgent string
+	*TracingOptions
+}
+
+type TracingOptions struct {
+	// Enabled set to true to enable ALL tracing
+	Enabled bool
+	// TraceErrorsOnly set to true to limit tracing to errors only
+	TraceErrorsOnly bool
+	// Output allows you to configure where the log output is outputted to. Defaults to os.Stdout
+	Output io.Writer
 }
 
 func newDefaultBaseURL() *url.URL {

--- a/query_params_test.go
+++ b/query_params_test.go
@@ -30,7 +30,6 @@ func Test_addParamsToUrl(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		// TODO: Add test cases.
 		{
 			name: "example test",
 			args: args{


### PR DESCRIPTION
- debug requests and responses by dumping them to a logger of some sort
- allow user to supply their own logger instead of the default std out
- Option to turn logger off/on
- Option for errors only logging
- Redacts secret from auth header

<img width="469" alt="Screenshot 2022-01-06 at 18 50 34" src="https://user-images.githubusercontent.com/82033495/148435211-86116b7d-b775-4699-a5cb-1c2e4dd9ca2f.png">

